### PR TITLE
fix: Lookup target selector translation

### DIFF
--- a/src/components/Lookup/components/TargetSelector.tsx
+++ b/src/components/Lookup/components/TargetSelector.tsx
@@ -25,7 +25,7 @@ export const TargetSelector = (props: ITargetSelector) => {
                 <Link
                     onClick={() => onEntitySelected(null)}
                     className={styles.targetSelectorLink}
-                    data-selected={!entities.find(x => x.selected)}>All</Link>
+                    data-selected={!entities.find(x => x.selected)}>{labels.all()}</Link>
                 {loadedEntities &&
                     <>
                         {loadedEntities.map((entity) => {

--- a/src/components/Lookup/translations.ts
+++ b/src/components/Lookup/translations.ts
@@ -26,5 +26,9 @@ export const lookupTranslations = {
     placeholder: {
         1033: "Search",
         1029: "Vyhledejte"
+    },
+    all: {
+        1033: "All",
+        1029: "Vše"
     }
 }


### PR DESCRIPTION
This pull request improves the localization support for the "All" option in the `TargetSelector` component by moving the label to the translation files. This ensures that the label is properly translated based on the user's language.