### PR TITLE
Add header text style and disable double-click navigation in grids

### DIFF
--- a/src/components/DatasetControl/EditColumns/EditColumns.tsx
+++ b/src/components/DatasetControl/EditColumns/EditColumns.tsx
@@ -88,7 +88,8 @@ export const EditColumns = (props: IEditColumnsProps) => {
                 footer: styles.panelFooter,
                 commands: styles.panelCommands,
                 scrollableContent: styles.panelScrollableContent,
-                content: styles.panelContent
+                content: styles.panelContent,
+                headerText: styles.headerText
             }}
             isFooterAtBottom
             onRenderFooterContent={() => {

--- a/src/components/DatasetControl/EditColumns/styles.ts
+++ b/src/components/DatasetControl/EditColumns/styles.ts
@@ -45,6 +45,9 @@ export const getEditColumnsStyles = (theme: ITheme) => {
             flexDirection: 'column',
             gap: 12
         },
+        headerText: {
+            whiteSpace: 'normal'
+        },
         selectors: {
             display: 'flex',
             flexDirection: 'column',

--- a/src/components/Grid/grid/ag-grid/AgGridModel.ts
+++ b/src/components/Grid/grid/ag-grid/AgGridModel.ts
@@ -291,6 +291,8 @@ export class AgGridModel extends EventEmitter<IAgGridModelEvents> {
             case this._grid.isColumnEditable(column.name, e.data):
             //do not navigate on aggregated/grouped rows
             case e.data?.getSummarizationType() !== 'none':
+            //do not allow double click navigation for editable grids (it creates confusion between double clicking read only columns to navigate and double clicking editable columns to edit)
+            case this._grid.isEditingEnabled():
             //do not navigate on checkbox column
             case column.name === DataProvider.CONST.CHECKBOX_COLUMN_KEY: {
                 break;


### PR DESCRIPTION
## Breaking Changes

**Double-Click Navigation Disabled in Editable Grids**

This PR removes double-click navigation functionality from editable grids. Users can no longer double-click on cells to open a record.
### Rationale

Double-click navigation was creating confusion in editable grids where:
- Double-clicking read-only columns was used for navigation
- Double-clicking editable columns was used for inline editing

These conflicting interactions made the UX ambiguous and error-prone.

### Migration Guide

To maintain record navigation in editable grids, you must:

1. **Designate a Primary Name Attribute** — Define a column as the primary link column in your column definition by marking it with the `isPrimary` flag
2. **Navigate via Link** — Users can click on the primary name attribute link to navigate to the record

### Additional Improvements
* Improved header text styling in the Edit Columns panel with proper text wrapping