### PR TITLE
fix: remove debug alert from Tab useEffect

### DIFF
--- a/src/components/Form/components/ui/tab/Tab.tsx
+++ b/src/components/Form/components/ui/tab/Tab.tsx
@@ -27,7 +27,6 @@ export const Tab = (props: ITabProps) => {
     });
 
     useEffect(() => {
-        alert('dsad')
         props.onColumnsPerRowChanged?.(columnsPerRow);
     }, [columnsPerRow]);
 


### PR DESCRIPTION
## Summary
- Remove a leftover `alert('dsad')` debug statement from the `useEffect` in `Tab.tsx`

## Testing
- N/A (dead debug code removal)