### PR TITLE
fix: form field state and validation propagation fixes

### DIFF
--- a/src/components/Form/components/adapters/field/Field.tsx
+++ b/src/components/Form/components/adapters/field/Field.tsx
@@ -1,6 +1,8 @@
 import { RequiredLevelEnum } from "@talxis/client-metadata";
 import { FieldContext } from "./context";
 import { IFieldValidationResult } from "@talxis/client-libraries";
+import React from "react";
+import { useForm } from "../root/context";
 
 export interface IFieldProps {
     name?: string;
@@ -10,7 +12,22 @@ export interface IFieldProps {
 }
 
 export const Field = (props: IFieldProps) => {
-    const { name, children } = props;
+    const form = useForm();
+    const { name, requiredLevel, validation, children } = props;
+
+    React.useEffect(() => {
+        if (!name) {
+            return;
+        }
+
+        if (requiredLevel != null) {
+            form.setFieldRequiredLevel(name, requiredLevel);
+        }
+
+        if (validation != null) {
+            form.setFieldValid(name, validation);
+        }
+    }, [name, requiredLevel, validation]);
 
     return <FieldContext.Provider value={name ?? null}>
         {children}

--- a/src/components/Form/components/adapters/field/Field.tsx
+++ b/src/components/Form/components/adapters/field/Field.tsx
@@ -1,9 +1,8 @@
 import { RequiredLevelEnum } from "@talxis/client-metadata";
 import { FieldContext } from "./context";
 import { IFieldValidationResult } from "@talxis/client-libraries";
-import { useForm } from "../root/context";
 
-interface IFieldProps {
+export interface IFieldProps {
     name?: string;
     requiredLevel?: RequiredLevelEnum | null;
     validation?: IFieldValidationResult | null;
@@ -11,17 +10,7 @@ interface IFieldProps {
 }
 
 export const Field = (props: IFieldProps) => {
-    const form = useForm();
-    const { name, children, requiredLevel, validation } = props;
-
-    if(name) {
-        if(requiredLevel != null) {
-            form.setFieldRequiredLevel(name, requiredLevel);
-        }
-        if(validation != null) {
-            form.setFieldValid(name, validation);
-        }
-    }
+    const { name, children } = props;
 
     return <FieldContext.Provider value={name ?? null}>
         {children}

--- a/src/components/Form/components/adapters/root/Root.tsx
+++ b/src/components/Form/components/adapters/root/Root.tsx
@@ -11,6 +11,7 @@ import { FormApi } from "@components/Form/internal/FormApi";
 import { IFormAfterSaveParams, IFormProps, IValidation } from "@components/Form/interfaces";
 import { FORM_LABELS } from "@components/Form/labels";
 import { LocalizationService } from "@utils";
+import { applyFieldConfigs } from "./fieldConfigs";
 
 initializeIcons();
 
@@ -29,12 +30,6 @@ export const Root = (props: IFormProps) => {
     const onRefreshRequested = async () => {
         await onLoad();
     };
-
-    React.useEffect(() => {
-        return () => {
-
-        }
-    }, []);
 
     React.useEffect(() => {
         onLoad();
@@ -81,6 +76,7 @@ export const RootInternal = (props: IFormProps & { deps: IOnLoadResult, onRefres
     useEventEmitter<IFormEvents>(form.events, 'onValidationSummaryChanged', (validationSummary: IValidation[]) => props.onValidationSummaryChanged?.(validationSummary));
 
     React.useEffect(() => {
+        applyFieldConfigs(form, children);
         onFormReady?.(formApi);
         return () => {
             form.destroy();

--- a/src/components/Form/components/adapters/root/Root.tsx
+++ b/src/components/Form/components/adapters/root/Root.tsx
@@ -23,7 +23,7 @@ export const Root = (props: IFormProps) => {
     const onLoad = async () => {
         setFormDeps(null);
         const result = await strategy.onLoad();
-        if(!isMounted()) return;
+        if (!isMounted()) return;
         setFormDeps(result);
     };
 
@@ -76,12 +76,15 @@ export const RootInternal = (props: IFormProps & { deps: IOnLoadResult, onRefres
     useEventEmitter<IFormEvents>(form.events, 'onValidationSummaryChanged', (validationSummary: IValidation[]) => props.onValidationSummaryChanged?.(validationSummary));
 
     React.useEffect(() => {
-        applyFieldConfigs(form, children);
         onFormReady?.(formApi);
         return () => {
             form.destroy();
         };
     }, []);
+
+    React.useEffect(() => {
+        applyFieldConfigs(form, children);
+    }, [children]);
 
     return (
         <FormLocalizationServiceContext.Provider value={localizationService}>

--- a/src/components/Form/components/adapters/root/fieldConfigs.ts
+++ b/src/components/Form/components/adapters/root/fieldConfigs.ts
@@ -1,0 +1,48 @@
+import React from "react";
+import { IForm } from "@components/Form/internal/FormModel";
+import { Field, IFieldProps } from "../field";
+
+interface IRegisteredFieldConfig {
+    name: string;
+    requiredLevel?: IFieldProps["requiredLevel"];
+    validation?: IFieldProps["validation"];
+}
+
+const collectFieldConfigs = (children: React.ReactNode): IRegisteredFieldConfig[] => {
+    const fieldConfigs = new Map<string, IRegisteredFieldConfig>();
+
+    const visitNode = (node: React.ReactNode): void => {
+        React.Children.forEach(node, (child) => {
+            if (!React.isValidElement(child)) {
+                return;
+            }
+
+            if (child.type === Field) {
+                const { name, requiredLevel, validation } = child.props as IFieldProps;
+
+                if (name) {
+                    fieldConfigs.set(name, { name, requiredLevel, validation });
+                }
+            }
+
+            if ("children" in child.props) {
+                visitNode(child.props.children);
+            }
+        });
+    };
+
+    visitNode(children);
+    return Array.from(fieldConfigs.values());
+};
+
+export const applyFieldConfigs = (form: IForm, children: React.ReactNode): void => {
+    collectFieldConfigs(children).forEach(({ name, requiredLevel, validation }) => {
+        if (requiredLevel != null) {
+            form.setFieldRequiredLevel(name, requiredLevel);
+        }
+
+        if (validation != null) {
+            form.setFieldValid(name, validation);
+        }
+    });
+};

--- a/src/components/Form/extensions/xrm-form/internal/form-xml-form/FormXmlAttribute.ts
+++ b/src/components/Form/extensions/xrm-form/internal/form-xml-form/FormXmlAttribute.ts
@@ -1,5 +1,5 @@
 import { EventEmitter, IEventEmitter, IField, IFieldValidationResult } from "@talxis/client-libraries";
-import type { IFormXmlAttribute, IFormXmlAttributeEvents, RequiredLevelEnum } from "./interfaces";
+import type { IFormXmlAttribute, IFormXmlAttributeEvents, IFormXmlModel, RequiredLevelEnum } from "./interfaces";
 
 export class FormXmlAttribute implements IFormXmlAttribute {
     public readonly events: IEventEmitter<IFormXmlAttributeEvents> = new EventEmitter<IFormXmlAttributeEvents>();
@@ -7,9 +7,11 @@ export class FormXmlAttribute implements IFormXmlAttribute {
     private _validation: IFieldValidationResult | null = null;
     private _requiredLevel: RequiredLevelEnum | null = null;
     private _field: IField;
+    private _formXmlModel: IFormXmlModel;
 
-    constructor(field: IField) {
+    constructor(field: IField, formXmlModel: IFormXmlModel) {
         this._field = field;
+        this._formXmlModel = formXmlModel;
     }
 
     public getValidation(): IFieldValidationResult | null {
@@ -19,6 +21,7 @@ export class FormXmlAttribute implements IFormXmlAttribute {
     public setValidation(validation: IFieldValidationResult): void {
         if (this._validation?.error === validation.error && this._validation?.errorMessage === validation.errorMessage) return;
         this._validation = validation;
+        this._formXmlModel.getForm().setFieldValid(this._field.getColumn().name, validation);
         this.events.dispatchEvent("onValidationChanged", validation);
     }
 
@@ -29,6 +32,7 @@ export class FormXmlAttribute implements IFormXmlAttribute {
     public setRequiredLevel(requiredLevel: RequiredLevelEnum): void {
         if (this._requiredLevel === requiredLevel) return;
         this._requiredLevel = requiredLevel;
+        this._formXmlModel.getForm().setFieldRequiredLevel(this._field.getColumn().name, requiredLevel);
         this.events.dispatchEvent("onRequiredLevelChanged", requiredLevel);
     }
 

--- a/src/components/Form/extensions/xrm-form/internal/form-xml-form/FormXmlForm.ts
+++ b/src/components/Form/extensions/xrm-form/internal/form-xml-form/FormXmlForm.ts
@@ -125,7 +125,7 @@ export class FormXmlForm implements IFormXmlModel {
 
     private _createAttributes(): void {
         this.getForm().getFields().map(field => {
-            this._attributes.set(field.getColumn().name, new FormXmlAttribute(field));
+            this._attributes.set(field.getColumn().name, new FormXmlAttribute(field, this));
         });
     }
 }

--- a/src/components/Form/extensions/xrm-form/internal/xrm-context/XrmAttribute.ts
+++ b/src/components/Form/extensions/xrm-form/internal/xrm-context/XrmAttribute.ts
@@ -41,10 +41,6 @@ export class XrmAttribute implements IXrmAttributeContext {
             error: !isValid,
             errorMessage: message ?? ''
         };
-        // Write through to the live form immediately - the FormXmlAttribute cache alone only
-        // reaches the record via a mounted Form.Field's render effect, which doesn't happen
-        // for attributes whose cell is currently hidden.
-        this._formContext.getFormXmlModel().getForm().setFieldValid(this.getName(), validation);
         this._attribute.setValidation(validation);
     }
 
@@ -91,10 +87,6 @@ export class XrmAttribute implements IXrmAttributeContext {
 
     public setRequiredLevel(level: Xrm.Attributes.RequirementLevel): void {
         const requiredLevel = FormModel.getRequiredLevelEnumFromXrm(level);
-        // Write through to the live form immediately - see setIsValid() for why the
-        // FormXmlAttribute cache alone isn't enough.
-        //along with validation - this is a struturual issue where its only propagated via rendered fields => we need to keep these settings on the form itself
-        this._formContext.getFormXmlModel().getForm().setFieldRequiredLevel(this.getName(), requiredLevel);
         this._attribute.setRequiredLevel(requiredLevel);
     }
 

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -9,7 +9,7 @@ const isLocalDevelopment = process.env.NODE_ENV !== 'production';
 const stories: NonNullable<StorybookConfig['stories']> = ['../src/**/*.stories.@(ts|tsx)', '../src/**/*.mdx'];
 
 if (!isLocalDevelopment) {
-  stories.splice(0, stories.length, '../src/**/!(*Scratch).stories.@(ts|tsx)', '../src/**/*.mdx');
+  stories.splice(0, stories.length, '../src/**/!(*Scratch|*Dev*).stories.@(ts|tsx)', '../src/**/*.mdx');
 }
 
 const config: StorybookConfig = {

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -4,9 +4,16 @@ import { fileURLToPath } from 'url';
 
 const storybookDir = path.dirname(fileURLToPath(import.meta.url));
 const githubPagesBasePath = '/base-controls/';
+const isLocalDevelopment = process.env.NODE_ENV !== 'production';
+
+const stories: NonNullable<StorybookConfig['stories']> = ['../src/**/*.stories.@(ts|tsx)', '../src/**/*.mdx'];
+
+if (!isLocalDevelopment) {
+  stories.splice(0, stories.length, '../src/**/!(*Scratch).stories.@(ts|tsx)', '../src/**/*.mdx');
+}
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.@(ts|tsx)', '../src/**/*.mdx'],
+  stories,
   addons: ['@storybook/addon-a11y', '@storybook/addon-docs'],
   framework: {
     name: '@storybook/react-vite',

--- a/storybook/src/stories/form/DevValidationScenarios.stories.tsx
+++ b/storybook/src/stories/form/DevValidationScenarios.stories.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { MessageBar, MessageBarType, Stack, Text } from '@fluentui/react'
+import { RequiredLevelEnum } from '@talxis/client-metadata'
+import { Form, MemoryStrategy } from '@talxis/base-controls/components/Form'
+import { renderStory } from './storyHelpers'
+import { getDemoRecord, getFormColumns, formMetadata } from '../../form/shared/formModel'
+
+const strategy = new MemoryStrategy({
+    onGetData: () => getDemoRecord(),
+    onGetColumns: () => getFormColumns(),
+    onGetMetadata: () => formMetadata,
+})
+
+const HiddenTabValidationRegistrationScenario = () => {
+    const [activeTab, setActiveTab] = React.useState('main')
+    const [validationSummary, setValidationSummary] = React.useState<{ fieldName?: string; errorMessage?: string }[]>([])
+
+    const hiddenFieldValidation = React.useMemo(() => ({
+        error: true,
+        errorMessage: 'Hidden validation should block save before the hidden tab is opened.',
+    }), [])
+
+    return (
+        <Form.Root strategy={strategy} onValidationSummaryChanged={setValidationSummary}>
+            <Stack tokens={{ childrenGap: 12 }}>
+                <MessageBar messageBarType={MessageBarType.info} isMultiline>
+                    <Stack tokens={{ childrenGap: 6 }}>
+                        <Text variant="mediumPlus">Scenario: hidden-tab validation registration</Text>
+                        <Text variant="small">
+                            Start on the <strong>Main</strong> tab and click save without opening <strong>Hidden validation</strong>.
+                            Save should be blocked immediately because the hidden field config is registered from <strong>Form.Root</strong>.
+                        </Text>
+                    </Stack>
+                </MessageBar>
+
+                {validationSummary.length > 0 && (
+                    <MessageBar messageBarType={MessageBarType.warning} isMultiline>
+                        <Stack tokens={{ childrenGap: 4 }}>
+                            <Text variant="smallPlus">Current validation summary</Text>
+                            {validationSummary.map((validation, index) => (
+                                <Text key={`${validation.fieldName ?? 'form'}-${index}`} variant="small">
+                                    {validation.fieldName ?? 'form'}: {validation.errorMessage ?? 'Validation error'}
+                                </Text>
+                            ))}
+                        </Stack>
+                    </MessageBar>
+                )}
+
+                <Form.Notifications />
+                <Form.Ribbon />
+                <Form.Tabs expandedTab={activeTab} onTabChange={setActiveTab}>
+                    <Form.Tab id="main" label="Main">
+                        <Form.Column>
+                            <Form.Section label="Visible fields" layout={{ lg: 1 }}>
+                                <Form.Field name="text">
+                                    <Form.Cell>
+                                        <Form.Control />
+                                    </Form.Cell>
+                                </Form.Field>
+                            </Form.Section>
+                        </Form.Column>
+                    </Form.Tab>
+                    <Form.Tab id="hidden-validation" label="Hidden validation">
+                        <Form.Column>
+                            <Form.Section label="Hidden field config" layout={{ lg: 1 }}>
+                                <Form.Field
+                                    name="phone"
+                                    requiredLevel={RequiredLevelEnum.ApplicationRequired}
+                                    validation={hiddenFieldValidation}
+                                >
+                                    <Form.Cell>
+                                        <Form.Control />
+                                    </Form.Cell>
+                                </Form.Field>
+                            </Form.Section>
+                        </Form.Column>
+                    </Form.Tab>
+                </Form.Tabs>
+            </Stack>
+        </Form.Root>
+    )
+}
+
+const meta = {
+    title: 'Form/Dev/Validation scenarios',
+    tags: ['dev-only'],
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            disable: true,
+        },
+    },
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const HiddenTabValidationRegistration: Story = {
+    name: 'Hidden-tab validation registration',
+    render: () => renderStory(<HiddenTabValidationRegistrationScenario />),
+}

--- a/storybook/src/stories/form/Scratch.stories.tsx
+++ b/storybook/src/stories/form/Scratch.stories.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { Form, MemoryStrategy } from '@talxis/base-controls/components/Form'
+import { renderStory } from './storyHelpers'
+import { getDemoRecord, getFormColumns, formMetadata } from '../../form/shared/formModel'
+
+const strategy = new MemoryStrategy({
+    onGetData: () => getDemoRecord(),
+    onGetColumns: () => getFormColumns(),
+    onGetMetadata: () => formMetadata,
+})
+
+const ScratchForm = () => {
+    const [activeTab, setActiveTab] = React.useState('main')
+
+    return (
+        <Form.Root strategy={strategy}>
+            <Form.Notifications />
+            <Form.Ribbon />
+            <Form.Tabs expandedTab={activeTab} onTabChange={setActiveTab}>
+                <Form.Tab id="main" label="Main">
+                    <Form.Column>
+                        <Form.Section label="Scratch area" layout={{ lg: 1 }}>
+                        </Form.Section>
+                    </Form.Column>
+                </Form.Tab>
+            </Form.Tabs>
+        </Form.Root>
+    )
+}
+
+const meta = {
+    title: 'Form/Dev/Scratch',
+    tags: ['dev-only'],
+    parameters: {
+        controls: { disable: true },
+        docs: {
+            disable: true,
+        },
+    },
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Playground: Story = {
+    name: 'Playground',
+    render: () => renderStory(<ScratchForm />),
+}


### PR DESCRIPTION
## Summary
- Stop `Field` from mutating form state during render and apply field configs correctly on form init/readiness
- Exclude scratch and dev-validation stories from production Storybook builds
- Move requiredLevel/validation write-through into `FormXmlAttribute` so it propagates via the model regardless of whether the field's cell is mounted, removing the previous dual-write from `XrmAttribute`

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] Verify field configs apply correctly on form load in Storybook
- [ ] Verify requiredLevel/validation set via Xrm form script propagates for both visible and hidden fields
- [ ] Confirm scratch/dev-validation stories are excluded from production Storybook build
