### PR TITLE
Allow overriding Xrm ribbon and notifications renderers

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "./storybook", "run", "storybook"],
+      "port": 6006
+    }
+  ]
+}

--- a/.claude/skills/scaffold-component-skill
+++ b/.claude/skills/scaffold-component-skill
@@ -1,0 +1,1 @@
+../../.github/skills/scaffold-component-skill

--- a/.claude/skills/scaffold-component-skill
+++ b/.claude/skills/scaffold-component-skill
@@ -1,1 +1,0 @@
-../../.github/skills/scaffold-component-skill

--- a/.claude/skills/scaffold-component-skill/SKILL.md
+++ b/.claude/skills/scaffold-component-skill/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: scaffold-component-skill
+description: 'Scaffold a React component folder with repository conventions. Use when creating a new component with optional overridable UI contract and strict empty-default templates.'
+argument-hint: 'name=<ComponentName> overridableUi=<yes|no>'
+---
+
+@.github/skills/scaffold-component-skill/SKILL.md

--- a/.github/instructions/browser-use.instructions.md
+++ b/.github/instructions/browser-use.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "**"
+description: "When (not) to use the browser to verify changes."
+---
+
+# Browser use
+
+Do not open the browser pane to test, click through, or visually verify changes unless the user directly asks for it in that turn.
+
+- Static checks (reading code, typechecking, running tests, linting) are fine on your own initiative.
+- If you believe a browser check would be valuable, say so and ask, or state it as a suggestion — don't just go do it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/instructions/component-codestyle.instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,2 @@
-.github/instructions/component-codestyle.instructions.md
+@.github/instructions/component-codestyle.instructions.md
+@.github/instructions/browser-use.instructions.md

--- a/src/components/Form/components/adapters/notifications/Notifications.tsx
+++ b/src/components/Form/components/adapters/notifications/Notifications.tsx
@@ -1,15 +1,19 @@
 import { useForm, useLocalizationService } from '../root/context';
-import { INotificationsProps, Notifications as NotificationsBase } from '@components/Notifications';
+import { INotificationsProps } from '@components/Notifications';
 import { useValidationSummary } from '../root';
+import { FormNotificationsComponents, IFormNotificationsComponents } from './components';
 
-export interface IFormNotificationsProps extends Omit<INotificationsProps, 'labels'> {}
+export interface IFormNotificationsProps extends Omit<INotificationsProps, 'labels'> {
+	components?: Partial<IFormNotificationsComponents>;
+}
 
 export const Notifications = (props: IFormNotificationsProps) => {
 	const form = useForm();
 	const localizationService = useLocalizationService();
 	const record = form.getRecord();
-	const { messages = [] } = props;
+	const { messages = [], components: componentsProp, ...notificationsProps } = props;
 	const validationSummary = useValidationSummary();
+	const components = { ...FormNotificationsComponents, ...componentsProp };
 
 	const getValidationNotifications = () => {
 		return validationSummary.map((validation) => {
@@ -34,7 +38,11 @@ export const Notifications = (props: IFormNotificationsProps) => {
 
 	const mergedMessages = [...messages, ...validationNotifications ?? []];
 
-	return <NotificationsBase {...props} labels={{
-		groupedNotificationsSummary: localizationService.getLocalizedString('groupedNotificationsSummary')
-	}} messages={mergedMessages} />;
+	return components.onRenderNotifications({
+		...notificationsProps,
+		labels: {
+			groupedNotificationsSummary: localizationService.getLocalizedString('groupedNotificationsSummary')
+		},
+		messages: mergedMessages,
+	});
 };

--- a/src/components/Form/components/adapters/notifications/components.tsx
+++ b/src/components/Form/components/adapters/notifications/components.tsx
@@ -1,0 +1,9 @@
+import { INotificationsProps, Notifications as NotificationsBase } from "@components/Notifications";
+
+export interface IFormNotificationsComponents {
+    onRenderNotifications: (props: INotificationsProps) => JSX.Element;
+}
+
+export const FormNotificationsComponents: IFormNotificationsComponents = {
+    onRenderNotifications: (props: INotificationsProps) => <NotificationsBase {...props} />,
+};

--- a/src/components/Form/components/adapters/notifications/index.ts
+++ b/src/components/Form/components/adapters/notifications/index.ts
@@ -1,1 +1,2 @@
 export * from './Notifications';
+export * from './components';

--- a/src/components/Form/extensions/xrm-form/components/xrm-form/components/components.tsx
+++ b/src/components/Form/extensions/xrm-form/components/xrm-form/components/components.tsx
@@ -1,8 +1,10 @@
-import { ControlComponents } from "@components/Form/components/adapters";
+import { ControlComponents, RibbonComponents, FormNotificationsComponents } from "@components/Form/components/adapters";
 import { IXrmFormComponents } from "../../../interfaces";
 import { TabComponents } from "@components/Form/components/ui";
 
 export const XrmFormComponents: IXrmFormComponents = {
     control: ControlComponents,
-    tabs: TabComponents
+    tabs: TabComponents,
+    ribbon: RibbonComponents,
+    notifications: FormNotificationsComponents
 }

--- a/src/components/Form/extensions/xrm-form/components/xrm-notifications/XrmNotifications.tsx
+++ b/src/components/Form/extensions/xrm-form/components/xrm-notifications/XrmNotifications.tsx
@@ -1,6 +1,7 @@
 import { Form } from "@components/Form/components/Form";
 import { INotification } from "@components/Form/extensions/xrm-form/internal/form-xml-form";
 import { useNotifications } from "./useNotifications";
+import { useXrmFormComponents } from "../xrm-form/context";
 
 const getNotifications = (notifications: INotification[]) => {
     return notifications.map(notification => ({
@@ -10,7 +11,8 @@ const getNotifications = (notifications: INotification[]) => {
 }
 
 export const XrmNotifications = () => {
-    const notifications = getNotifications(useNotifications());
+    const messages = getNotifications(useNotifications());
+    const components = useXrmFormComponents();
 
-    return <Form.Notifications messages={notifications} />
+    return <Form.Notifications messages={messages} components={components.notifications} />
 }

--- a/src/components/Form/extensions/xrm-form/components/xrm-ribbon/XrmRibbon.tsx
+++ b/src/components/Form/extensions/xrm-form/components/xrm-ribbon/XrmRibbon.tsx
@@ -1,10 +1,12 @@
 import { Form } from "@components/Form/components/Form"
 import { useXrmFormContext } from "../context";
+import { useXrmFormComponents } from "../xrm-form/context";
 
 
 //TODO: this on save is wrong, we should have basic ribbon commandbar => taking buttons and rendering them correctly, handling the loadings and etc,
 //then have the form ribbon that adds the various events and etc, then we can use that ribbon here and override the ribbon button
 export const XrmRibbon = () => {
     const formContext = useXrmFormContext();
-    return <Form.Ribbon onSave={() => formContext.data.save()} />
+    const components = useXrmFormComponents();
+    return <Form.Ribbon onSave={() => formContext.data.save()} components={components.ribbon} />
 }

--- a/src/components/Form/extensions/xrm-form/interfaces.ts
+++ b/src/components/Form/extensions/xrm-form/interfaces.ts
@@ -2,6 +2,8 @@ import type { IFormApi, IFormEventHandlers } from "@components/Form/interfaces";
 import type { IFormLabels } from "@components/Form/labels";
 import type { IFormStrategy } from "@components/Form/strategies";
 import type { IControlComponents } from "@components/Form/components/adapters/control/components";
+import type { IRibbonComponents } from "@components/Form/components/adapters/ribbon/components";
+import type { IFormNotificationsComponents } from "@components/Form/components/adapters/notifications/components";
 import { ITabsComponents } from "@components/Form/components/ui";
 
 /**
@@ -239,5 +241,7 @@ export interface IXrmFormProps extends Partial<IFormEventHandlers> {
 export interface IXrmFormComponents {
     control: Partial<IControlComponents>;
     tabs: Partial<ITabsComponents>;
+    ribbon: Partial<IRibbonComponents>;
+    notifications: Partial<IFormNotificationsComponents>;
 }
 

--- a/storybook/src/stories/form/ReactComposeCustomComponents.stories.tsx
+++ b/storybook/src/stories/form/ReactComposeCustomComponents.stories.tsx
@@ -655,6 +655,277 @@ const FormExample = () => {
   );
 };`,
     },
+    {
+        id: 'custom-ribbon',
+        title: 'Replace the ribbon renderer',
+        summary: 'Use `Form.Ribbon components.onRenderCommandBar` to render a fully native Material UI toolbar, wiring Save directly through `useForm()`.',
+        notes: [
+            'Use this when the host application renders the rest of its UI in Material UI and wants a real MUI Button, not the runtime-supplied Fluent Save button.',
+            '`useForm()` gives direct access to `save()` from inside the custom renderer; the runtime-supplied "save" item is ignored entirely.',
+            'The "unsaved-changes" far item is still read from the runtime to drive the dirty-state chip, since that stays reactive for free.',
+        ],
+        previewCode: `${sharedStrategyCode}
+function MaterialRibbon(props) {
+  const { farItems = [] } = props;
+  const form = useForm();
+  const unsavedItem = farItems.find((item) => item.key === "unsaved-changes");
+
+  return (
+    <AppBar position="static" color="default" elevation={0} sx={{ borderRadius: 2, mb: 2 }}>
+      <Toolbar variant="dense" sx={{ justifyContent: "space-between", gap: 1 }}>
+        <MuiButton variant="contained" size="small" onClick={() => form.save()}>
+          Save
+        </MuiButton>
+        {unsavedItem && <Chip label={unsavedItem.text} color="warning" size="small" variant="outlined" />}
+      </Toolbar>
+    </AppBar>
+  );
+}
+
+const FormExample = () => {
+  const [activeTab, setActiveTab] = React.useState("general");
+
+  return (
+    <Form.Root strategy={strategy}>
+      <Form.Notifications />
+      <Form.Ribbon
+        components={{
+          onRenderCommandBar: (commandBarProps) => <MaterialRibbon {...commandBarProps} />,
+        }}
+      />
+      <Form.Tabs expandedTab={activeTab} onTabChange={setActiveTab}>
+        <Form.Tab id="general" label="General">
+          <Form.Column>
+            <Form.Section label="Identity" layout={{ lg: 2 }}>
+              <Form.Field name="text"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+              <Form.Field name="phone"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+              <Form.Field name="url"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+            </Form.Section>
+          </Form.Column>
+        </Form.Tab>
+      </Form.Tabs>
+    </Form.Root>
+  );
+};`,
+        code: `${sharedStrategyCode}
+function MaterialRibbon(props) {
+  const { farItems = [] } = props;
+  const form = useForm();
+  const unsavedItem = farItems.find((item) => item.key === "unsaved-changes");
+
+  return (
+    <AppBar position="static" color="default" elevation={0} sx={{ borderRadius: 2, mb: 2 }}>
+      <Toolbar variant="dense" sx={{ justifyContent: "space-between", gap: 1 }}>
+        <MuiButton variant="contained" size="small" onClick={() => form.save()}>
+          Save
+        </MuiButton>
+        {unsavedItem && <Chip label={unsavedItem.text} color="warning" size="small" variant="outlined" />}
+      </Toolbar>
+    </AppBar>
+  );
+}
+
+const FormExample = () => {
+  const [activeTab, setActiveTab] = React.useState("general");
+
+  return (
+    <Form.Root strategy={strategy}>
+      <Form.Notifications />
+      <Form.Ribbon
+        components={{
+          onRenderCommandBar: (commandBarProps) => <MaterialRibbon {...commandBarProps} />,
+        }}
+      />
+      <Form.Tabs expandedTab={activeTab} onTabChange={setActiveTab}>
+        <Form.Tab id="general" label="General">
+          <Form.Column>
+            <Form.Section label="Identity" layout={{ lg: 2 }}>
+              <Form.Field name="text"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+              <Form.Field name="phone"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+              <Form.Field name="url"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+            </Form.Section>
+          </Form.Column>
+        </Form.Tab>
+      </Form.Tabs>
+    </Form.Root>
+  );
+};`,
+    },
+    {
+        id: 'custom-notifications',
+        title: 'Replace the notifications renderer',
+        summary: 'Use `Form.Notifications components.onRenderNotifications` to render dismissable, self-clearing Material UI Snackbars instead of the stock notifications list.',
+        notes: [
+            'In React compose, notifications are just a controlled `messages` prop; there is no separate runtime API to call into.',
+            'Each toast auto-hides after 6 seconds and can also be dismissed early via its close button.',
+        ],
+        previewCode: `${sharedStrategyCode}
+function MaterialNotifications(props) {
+  const { messages = [] } = props;
+  const [dismissed, setDismissed] = React.useState({});
+
+  const severityByLevel = {
+    ERROR: "error",
+    WARNING: "warning",
+    INFO: "info",
+  };
+
+  const dismiss = (key) => {
+    setDismissed((prev) => ({ ...prev, [key]: true }));
+  };
+
+  return (
+    <>
+      {messages.map((message, index) => {
+        const key = \`\${index}-\${message.text}\`;
+
+        if (dismissed[key]) {
+          return null;
+        }
+
+        return (
+          <Snackbar
+            key={key}
+            open
+            autoHideDuration={6000}
+            onClose={(_event, reason) => reason !== "clickaway" && dismiss(key)}
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            sx={{ bottom: \`\${16 + index * 64}px !important\` }}
+          >
+            <Alert
+              severity={severityByLevel[message.level] ?? "info"}
+              variant="filled"
+              onClose={() => dismiss(key)}
+              sx={{ width: "100%" }}
+            >
+              {message.text}
+            </Alert>
+          </Snackbar>
+        );
+      })}
+    </>
+  );
+}
+
+const FormExample = () => {
+  const [activeTab, setActiveTab] = React.useState("general");
+  const [messages, setMessages] = React.useState([]);
+
+  const addNotification = (level) => {
+    setMessages((prev) => [...prev, { text: \`Custom \${level.toLowerCase()} notification\`, level }]);
+  };
+
+  return (
+    <Form.Root strategy={strategy}>
+      <Stack horizontal tokens={{ childrenGap: 8 }} styles={{ root: { marginBottom: 12 } }}>
+        <MuiButton variant="contained" onClick={() => addNotification("INFO")}>Add info</MuiButton>
+        <MuiButton variant="outlined" color="warning" onClick={() => addNotification("WARNING")}>Add warning</MuiButton>
+        <MuiButton variant="outlined" color="error" onClick={() => addNotification("ERROR")}>Add error</MuiButton>
+      </Stack>
+      <Form.Notifications
+        messages={messages}
+        components={{
+          onRenderNotifications: (notificationsProps) => <MaterialNotifications {...notificationsProps} />,
+        }}
+      />
+      <Form.Ribbon />
+      <Form.Tabs expandedTab={activeTab} onTabChange={setActiveTab}>
+        <Form.Tab id="general" label="General">
+          <Form.Column>
+            <Form.Section label="Identity" layout={{ lg: 2 }}>
+              <Form.Field name="text"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+              <Form.Field name="phone"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+            </Form.Section>
+          </Form.Column>
+        </Form.Tab>
+      </Form.Tabs>
+    </Form.Root>
+  );
+};`,
+        code: `${sharedStrategyCode}
+function MaterialNotifications(props) {
+  const { messages = [] } = props;
+  const [dismissed, setDismissed] = React.useState({});
+
+  const severityByLevel = {
+    ERROR: "error",
+    WARNING: "warning",
+    INFO: "info",
+  };
+
+  const dismiss = (key) => {
+    setDismissed((prev) => ({ ...prev, [key]: true }));
+  };
+
+  return (
+    <>
+      {messages.map((message, index) => {
+        const key = \`\${index}-\${message.text}\`;
+
+        if (dismissed[key]) {
+          return null;
+        }
+
+        return (
+          <Snackbar
+            key={key}
+            open
+            autoHideDuration={6000}
+            onClose={(_event, reason) => reason !== "clickaway" && dismiss(key)}
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            sx={{ bottom: \`\${16 + index * 64}px !important\` }}
+          >
+            <Alert
+              severity={severityByLevel[message.level] ?? "info"}
+              variant="filled"
+              onClose={() => dismiss(key)}
+              sx={{ width: "100%" }}
+            >
+              {message.text}
+            </Alert>
+          </Snackbar>
+        );
+      })}
+    </>
+  );
+}
+
+const FormExample = () => {
+  const [activeTab, setActiveTab] = React.useState("general");
+  const [messages, setMessages] = React.useState([]);
+
+  const addNotification = (level) => {
+    setMessages((prev) => [...prev, { text: \`Custom \${level.toLowerCase()} notification\`, level }]);
+  };
+
+  return (
+    <Form.Root strategy={strategy}>
+      <Stack horizontal tokens={{ childrenGap: 8 }} styles={{ root: { marginBottom: 12 } }}>
+        <MuiButton variant="contained" onClick={() => addNotification("INFO")}>Add info</MuiButton>
+        <MuiButton variant="outlined" color="warning" onClick={() => addNotification("WARNING")}>Add warning</MuiButton>
+        <MuiButton variant="outlined" color="error" onClick={() => addNotification("ERROR")}>Add error</MuiButton>
+      </Stack>
+      <Form.Notifications
+        messages={messages}
+        components={{
+          onRenderNotifications: (notificationsProps) => <MaterialNotifications {...notificationsProps} />,
+        }}
+      />
+      <Form.Ribbon />
+      <Form.Tabs expandedTab={activeTab} onTabChange={setActiveTab}>
+        <Form.Tab id="general" label="General">
+          <Form.Column>
+            <Form.Section label="Identity" layout={{ lg: 2 }}>
+              <Form.Field name="text"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+              <Form.Field name="phone"><Form.Cell><Form.Control /></Form.Cell></Form.Field>
+            </Form.Section>
+          </Form.Column>
+        </Form.Tab>
+      </Form.Tabs>
+    </Form.Root>
+  );
+};`,
+    },
 ]
 
 const renderCustomComponentsExample = (example: ICustomComponentsExample) => {
@@ -712,12 +983,16 @@ Replace parts of the React compose rendering with your own components while the 
 
 Custom components don't opt you out of the runtime — they let you own presentation for one area while everything else (binding, validation, notifications, dirty tracking, save) stays managed.
 
+> Some stories below use Material UI purely to demonstrate that presentation is fully swappable, not because it's the recommended choice. To keep a form visually coherent, prefer sticking to Fluent UI where possible — that's what the rest of the runtime renders with.
+
 ## What you can replace
 
 - **Presentation shells** — swap the tabs renderer for a stepper, wizard, sidebar, or other domain-specific navigation.
 - **Field widgets** — compose custom read/write UI with \`Form.Field\`, \`Form.Cell\`, and \`useField\` that still participates in validation and save flow.
 - **Embedded content** — mix runtime-managed controls with summaries, helper panels, maps, and other custom cells.
 - **Section framing** — render fields through a custom section wrapper when one area needs presentation the stock section chrome doesn't provide.
+- **Ribbon** — replace the command bar with a native toolbar while \`useForm()\` still drives save and dirty state.
+- **Notifications** — replace the notifications list with a custom renderer over the same controlled \`messages\` prop.
                 `.trim(),
             },
         },
@@ -828,4 +1103,54 @@ Renders fields through a fully custom section wrapper when one area needs distin
         },
     },
     render: () => renderStory(renderCustomComponentsExample(samplesById['custom-sections-and-labels'])),
+}
+
+export const ReplaceRibbonRenderer: Story = {
+    name: 'Replace the ribbon renderer',
+    parameters: {
+        docs: {
+            canvas: {
+                sourceState: 'none',
+                additionalActions: [],
+            },
+            source: {
+                code: samplesById['custom-ribbon'].previewCode ?? samplesById['custom-ribbon'].code,
+            },
+            description: {
+                story: `
+Renders a native Material UI toolbar through \`Form.Ribbon components.onRenderCommandBar\`, wiring Save directly through \`useForm()\`.
+
+- swaps the ribbon presentation layer for real MUI components (AppBar, Toolbar, Button, Chip)
+- ignores the runtime's \`commandBarButtonAs\` renderer entirely; Save is a plain MUI \`Button\` calling \`useForm().save()\`
+- still reads the "unsaved-changes" far item to drive a dirty-state \`Chip\`
+                `.trim(),
+            },
+        },
+    },
+    render: () => renderStory(renderCustomComponentsExample(samplesById['custom-ribbon'])),
+}
+
+export const ReplaceNotificationsRenderer: Story = {
+    name: 'Replace the notifications renderer',
+    parameters: {
+        docs: {
+            canvas: {
+                sourceState: 'none',
+                additionalActions: [],
+            },
+            source: {
+                code: samplesById['custom-notifications'].previewCode ?? samplesById['custom-notifications'].code,
+            },
+            description: {
+                story: `
+Renders dismissable, self-clearing Material UI \`Snackbar\`/\`Alert\` toasts through \`Form.Notifications components.onRenderNotifications\`.
+
+- swaps the notifications presentation layer for real MUI components (\`Snackbar\`, \`Alert\`)
+- notifications are a plain controlled \`messages\` prop; there is no separate runtime API to call
+- each toast auto-hides after 6 seconds or can be dismissed early via its close button
+                `.trim(),
+            },
+        },
+    },
+    render: () => renderStory(renderCustomComponentsExample(samplesById['custom-notifications'])),
 }

--- a/storybook/src/stories/form/ReactComposeLivePreview.tsx
+++ b/storybook/src/stories/form/ReactComposeLivePreview.tsx
@@ -1,9 +1,10 @@
 import * as Babel from "@babel/standalone"
 import React from "react"
 import { ComboBox, Icon, IconButton, Slider, Stack, Text, TextField } from "@fluentui/react"
-import { Form, MemoryStrategy, useField } from "@talxis/base-controls/components/Form"
+import { Form, MemoryStrategy, useField, useForm } from "@talxis/base-controls/components/Form"
 import { OpenMap } from "../../form/react-form/OpenMap"
 import { Step, StepButton, StepContent, Stepper } from "@mui/material"
+import { Alert, AppBar, Button as MuiButton, Chip, Snackbar, Stack as MuiStack, Toolbar } from "@mui/material"
 import { getDemoRecord, getFormColumns } from "../../form/shared/formModel"
 
 interface IReactComposeLivePreviewProps {
@@ -31,6 +32,13 @@ export const ReactComposeLivePreview = (props: IReactComposeLivePreviewProps) =>
             MuiStep: Step,
             MuiStepButton: StepButton,
             MuiStepContent: StepContent,
+            Alert,
+            AppBar,
+            MuiButton,
+            Chip,
+            MuiStack,
+            Toolbar,
+            Snackbar,
         }),
         [],
     )
@@ -49,6 +57,7 @@ export const ReactComposeLivePreview = (props: IReactComposeLivePreviewProps) =>
                 "React",
                 "Form",
                 "useField",
+                "useForm",
                 "Stack",
                 "FluentText",
                 "TextField",
@@ -61,6 +70,13 @@ export const ReactComposeLivePreview = (props: IReactComposeLivePreviewProps) =>
                 "MuiStep",
                 "MuiStepButton",
                 "MuiStepContent",
+                "Alert",
+                "AppBar",
+                "MuiButton",
+                "Chip",
+                "MuiStack",
+                "Toolbar",
+                "Snackbar",
                 "MemoryStrategy",
                 "recordData",
                 "modelColumns",
@@ -81,6 +97,7 @@ export const ReactComposeLivePreview = (props: IReactComposeLivePreviewProps) =>
                 React,
                 Form,
                 useField,
+                useForm,
                 fluent.Stack,
                 fluent.FluentText,
                 fluent.TextField,
@@ -93,6 +110,13 @@ export const ReactComposeLivePreview = (props: IReactComposeLivePreviewProps) =>
                 fluent.MuiStep,
                 fluent.MuiStepButton,
                 fluent.MuiStepContent,
+                fluent.Alert,
+                fluent.AppBar,
+                fluent.MuiButton,
+                fluent.Chip,
+                fluent.MuiStack,
+                fluent.Toolbar,
+                fluent.Snackbar,
                 MemoryStrategy,
                 recordData,
                 modelColumns,

--- a/storybook/src/stories/form/XrmCustomComponents.stories.tsx
+++ b/storybook/src/stories/form/XrmCustomComponents.stories.tsx
@@ -247,6 +247,147 @@ const XrmCustomComponentsExample = () => {
   );
 };`,
     },
+    {
+        id: 'ribbon',
+        title: 'Replace the ribbon renderer',
+        summary: 'Swap the default command bar shell with a fully native Material UI toolbar, wiring Save directly to formContext.data.save().',
+        notes: [
+            'Use this when the host application renders the rest of its UI in Material UI and wants a real MUI Button, not the runtime-supplied Fluent Save button.',
+            'The runtime-supplied "save" item (and its commandBarButtonAs renderer) is ignored entirely; only the "unsaved-changes" far item is read, to drive the dirty-state chip.',
+        ],
+        code: `const strategy = new XrmMemoryStrategy({
+  onGetData: () => getCustomComponentsRecord(),
+  onGetColumns: () => xrmCustomComponentsModelStore.getRuntimeColumns(),
+  onGetMetadata: () => formMetadata,
+  onGetFormXml: () => getCustomComponentsFormXml(),
+});
+
+function MaterialRibbon(props) {
+  const { farItems = [], onSave } = props;
+  const unsavedItem = farItems.find((item) => item.key === "unsaved-changes");
+
+  return (
+    <AppBar position="static" color="default" elevation={0} sx={{ borderRadius: 2, mb: 2 }}>
+      <Toolbar variant="dense" sx={{ justifyContent: "space-between", gap: 1 }}>
+        <MuiButton variant="contained" size="small" onClick={onSave}>
+          Save
+        </MuiButton>
+        {unsavedItem && <Chip label={unsavedItem.text} color="warning" size="small" variant="outlined" />}
+      </Toolbar>
+    </AppBar>
+  );
+}
+
+const XrmCustomComponentsExample = () => {
+  const [formContext, setFormContext] = React.useState(null);
+
+  return (
+    <XrmForm
+      strategy={strategy}
+      onFormReady={({ formContext: nextFormContext }) => setFormContext(nextFormContext)}
+      components={{
+        ribbon: {
+          onRenderCommandBar: (commandBarProps) => (
+            <MaterialRibbon {...commandBarProps} onSave={() => formContext?.data.save()} />
+          ),
+        },
+      }}
+    />
+  );
+};`,
+    },
+    {
+        id: 'notifications',
+        title: 'Replace the notifications renderer',
+        summary: 'Swap the default notifications list with dismissable, self-clearing Material UI Snackbars while notifications are still raised through the standard formContext.ui API.',
+        notes: [
+            'Use this when the host application renders the rest of its UI in Material UI and wants form notifications to match, stacked as toasts instead of an inline list.',
+            'Each toast auto-hides after 6 seconds and can also be dismissed early via its close button; dismissal is local to this renderer, not a call back into the runtime.',
+            'The buttons in this example call formContext.ui.setFormNotification to raise notifications, exactly like a form script would.',
+        ],
+        code: `const strategy = new XrmMemoryStrategy({
+  onGetData: () => getCustomComponentsRecord(),
+  onGetColumns: () => xrmCustomComponentsModelStore.getRuntimeColumns(),
+  onGetMetadata: () => formMetadata,
+  onGetFormXml: () => getCustomComponentsFormXml(),
+});
+
+function MaterialNotifications(props) {
+  const { messages = [] } = props;
+  const [dismissed, setDismissed] = React.useState({});
+
+  const severityByLevel = {
+    ERROR: "error",
+    WARNING: "warning",
+    INFO: "info",
+  };
+
+  const dismiss = (key) => {
+    setDismissed((prev) => ({ ...prev, [key]: true }));
+  };
+
+  return (
+    <>
+      {messages.map((message, index) => {
+        const key = \`\${index}-\${message.text}\`;
+
+        if (dismissed[key]) {
+          return null;
+        }
+
+        return (
+          <Snackbar
+            key={key}
+            open
+            autoHideDuration={6000}
+            onClose={(_event, reason) => reason !== "clickaway" && dismiss(key)}
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            sx={{ bottom: \`\${16 + index * 64}px !important\` }}
+          >
+            <Alert
+              severity={severityByLevel[message.level] ?? "info"}
+              variant="filled"
+              onClose={() => dismiss(key)}
+              sx={{ width: "100%" }}
+            >
+              {message.text}
+            </Alert>
+          </Snackbar>
+        );
+      })}
+    </>
+  );
+}
+
+const XrmCustomComponentsExample = () => {
+  const [formContext, setFormContext] = React.useState(null);
+
+  const addNotification = (level) => {
+    const uniqueId = \`custom-\${level}-\${Date.now()}\`;
+    formContext?.ui.setFormNotification(\`Custom \${level.toLowerCase()} notification\`, level, uniqueId);
+  };
+
+  return (
+    <MuiStack spacing={2}>
+      <MuiStack direction="row" spacing={1}>
+        <MuiButton variant="contained" onClick={() => addNotification("INFO")}>Add info</MuiButton>
+        <MuiButton variant="outlined" color="warning" onClick={() => addNotification("WARNING")}>Add warning</MuiButton>
+        <MuiButton variant="outlined" color="error" onClick={() => addNotification("ERROR")}>Add error</MuiButton>
+      </MuiStack>
+
+      <XrmForm
+        strategy={strategy}
+        onFormReady={({ formContext: nextFormContext }) => setFormContext(nextFormContext)}
+        components={{
+          notifications: {
+            onRenderNotifications: (notificationsProps) => <MaterialNotifications {...notificationsProps} />,
+          },
+        }}
+      />
+    </MuiStack>
+  );
+};`,
+    },
 ]
 
 const renderCustomComponentsExample = (example: IXrmCustomComponentsExample) => {
@@ -290,10 +431,14 @@ Replace parts of the Xrm rendering with your own components while the layout sta
 
 These stories keep the same FormXml-driven structure and \`formContext\` surface; only the rendering of selected pieces changes.
 
+> Some stories below use Material UI purely to demonstrate that presentation is fully swappable, not because it's the recommended choice. To keep a form visually coherent, prefer sticking to Fluent UI where possible — that's what the rest of the runtime renders with.
+
 ## What you can replace
 
 - **Control presentation** — swap the rendered UI for selected Xrm controls without touching the rest of the form.
 - **Tabs shell** — replace the tabs renderer with a custom stepper, wizard, or other navigation shell while tab state and content stay runtime-driven.
+- **Ribbon** — replace the command bar shell with a custom toolbar while the Save button and dirty-state behavior stay runtime-driven.
+- **Notifications** — replace the notifications list with a custom renderer while notifications are still raised through \`formContext.ui.setFormNotification\`.
 
 Each story runs its own isolated form instance and opens directly in the live preview for that scenario.
                 `.trim(),
@@ -350,4 +495,48 @@ Replaces the default tabs shell with a custom stepper-based renderer while prese
         },
     },
     render: () => renderStory(renderCustomComponentsExample(samplesById.tabs)),
+}
+
+export const ReplaceRibbonRenderer: Story = {
+    name: 'Replace the ribbon renderer',
+    parameters: {
+        docs: {
+            canvas: {
+                sourceState: 'none',
+                additionalActions: [],
+            },
+            description: {
+                story: `
+Replaces the default command bar shell with a native Material UI toolbar, wiring Save directly to \`formContext.data.save()\` instead of the runtime-supplied Fluent button.
+
+- swaps the ribbon presentation layer for real MUI components (AppBar, Toolbar, Button, Chip)
+- ignores the runtime's \`commandBarButtonAs\` renderer entirely; Save is a plain MUI \`Button\`
+- still reads the "unsaved-changes" far item to drive a dirty-state \`Chip\`
+                `.trim(),
+            },
+        },
+    },
+    render: () => renderStory(renderCustomComponentsExample(samplesById.ribbon)),
+}
+
+export const ReplaceNotificationsRenderer: Story = {
+    name: 'Replace the notifications renderer',
+    parameters: {
+        docs: {
+            canvas: {
+                sourceState: 'none',
+                additionalActions: [],
+            },
+            description: {
+                story: `
+Replaces the default notifications list with dismissable, self-clearing Material UI \`Snackbar\`/\`Alert\` toasts, driven by \`formContext.ui.setFormNotification\`.
+
+- swaps the notifications presentation layer for real MUI components (\`Snackbar\`, \`Alert\`)
+- each toast auto-hides after 6 seconds or can be dismissed early via its close button
+- includes buttons to add info/warning/error notifications so you can see the custom renderer react live
+                `.trim(),
+            },
+        },
+    },
+    render: () => renderStory(renderCustomComponentsExample(samplesById.notifications)),
 }

--- a/storybook/src/stories/form/XrmCustomComponentsLivePreview.tsx
+++ b/storybook/src/stories/form/XrmCustomComponentsLivePreview.tsx
@@ -5,6 +5,7 @@ import { ControlComponents } from "@talxis/base-controls/components/Form/compone
 import { ComboBox, Stack, Text } from "@fluentui/react"
 import { FormControl, InputLabel, MenuItem, Select, Slider as MuiSlider, TextField as MuiTextField } from "@mui/material"
 import { Step, StepButton, StepContent, Stepper } from "@mui/material"
+import { Alert, AppBar, Button as MuiButton, Chip, Snackbar, Stack as MuiStack, Toolbar } from "@mui/material"
 import { formMetadata } from "../../form/shared/formModel"
 import { getCustomComponentsFormXml, getCustomComponentsRecord, xrmCustomComponentsModelStore } from "../../form/xrm-form/xrmCustomComponentsModel"
 
@@ -47,6 +48,13 @@ export const XrmCustomComponentsLivePreview = (props: IXrmCustomComponentsLivePr
                 "Step",
                 "StepButton",
                 "StepContent",
+                "Alert",
+                "AppBar",
+                "MuiButton",
+                "Chip",
+                "MuiStack",
+                "Toolbar",
+                "Snackbar",
                 `${transformed}
                  return typeof XrmCustomComponentsExample !== "undefined" ? XrmCustomComponentsExample : null;`,
             )
@@ -74,6 +82,13 @@ export const XrmCustomComponentsLivePreview = (props: IXrmCustomComponentsLivePr
                 Step,
                 StepButton,
                 StepContent,
+                Alert,
+                AppBar,
+                MuiButton,
+                Chip,
+                MuiStack,
+                Toolbar,
+                Snackbar,
             ) as React.ComponentType | null
 
             return { Component, error: null as string | null }


### PR DESCRIPTION
## Summary
- Adds `components.ribbon`/`components.notifications` overrides to `XrmForm` (and the underlying `Form.Ribbon`/`Form.Notifications` adapters), mirroring the existing control/tabs override pattern.
- Adds Storybook demos showing custom ribbon and notifications renderers for both the Xrm and React-compose custom-components stories (Material UI used purely to demonstrate swappability, with a note that Fluent UI stays the recommended choice for visual coherence).
- Tracks `.claude/` config and `CLAUDE.md` in git (previously symlinked into `.github/instructions` and `.github/skills`); `CLAUDE.md` and the scaffold skill now use `@import` instead of symlinks.
- Adds a new `.github/instructions/browser-use.instructions.md` instructing not to test changes in the browser unless directly asked.

## Test plan
- [ ] `npm run storybook` and check `Form/Xrm/Custom Components` → "Replace the ribbon renderer" / "Replace the notifications renderer"
- [ ] Same for `Form/React compose/Custom Components`
- [ ] Confirm existing ribbon/notifications behavior (Save, dirty state, Xrm `formContext.ui.setFormNotification`) is unchanged when no custom `components` override is passed