### PR TITLE
fix: expose xrm attribute validation state and align form validity checks

### DIFF
--- a/src/components/Form/extensions/xrm-form/interfaces.ts
+++ b/src/components/Form/extensions/xrm-form/interfaces.ts
@@ -72,6 +72,8 @@ export interface IXrmAttributeContext {
     setRequiredLevel(level: Xrm.Attributes.RequirementLevel): void;
     /** Indicates whether the attribute is dirty. */
     getIsDirty(): boolean;
+    /** Returns whether the attribute currently passes validation. */
+    isValid: () => boolean;
     /** Returns the submit mode. */
     getSubmitMode(): Xrm.SubmitMode;
     /** Fires the change handlers for the attribute. */

--- a/src/components/Form/extensions/xrm-form/internal/xrm-context/XrmAttribute.ts
+++ b/src/components/Form/extensions/xrm-form/internal/xrm-context/XrmAttribute.ts
@@ -29,6 +29,10 @@ export class XrmAttribute implements IXrmAttributeContext {
         return this._getField().getValue();
     }
 
+    public isValid(): boolean {
+        return !this._getField().isValid().error
+    }
+
     public setValue(value: any): void {
         // Real Xrm.Page doesn't fire onChange handlers for a scripted setValue() call unless
         // the script explicitly calls fireOnChange() afterwards.

--- a/src/components/Form/internal/FormModel.ts
+++ b/src/components/Form/internal/FormModel.ts
@@ -112,7 +112,7 @@ export class FormModel implements IForm {
     }
 
     public isValid(): boolean {
-        return this._dataProvider.isValid();
+        return this._record.isValid();
     }
 
     public getData(): { [key: string]: any } {


### PR DESCRIPTION
## Summary
- Add `isValid()` to `IXrmAttributeContext` and implement it on `XrmAttribute`, based on the underlying field's validation error state.
- Change `FormModel.isValid()` to defer to `this._record.isValid()` instead of `this._dataProvider.isValid()`, so form validity reflects the xrm record/attribute validation state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)