### PR TITLE
fix: use plain dataset display names in model builder panel

### DIFF
--- a/storybook/src/form/shared/ModelBuilderPanel.tsx
+++ b/storybook/src/form/shared/ModelBuilderPanel.tsx
@@ -433,8 +433,8 @@ export const ModelBuilderPanel = (props: IModelBuilderPanelProps) => {
                 PrimaryNameAttribute: "name",
                 LogicalName: "field",
                 EntitySetName: "fields",
-                DisplayName: { UserLocalizedLabel: { Label: "Field", LanguageCode: 1033 }, LocalizedLabels: [] },
-                DisplayCollectionName: { UserLocalizedLabel: { Label: "Fields", LanguageCode: 1033 }, LocalizedLabels: [] },
+                DisplayName: "Field",
+                DisplayCollectionName: "Fields"
             },
         })
         const ds = new Dataset(provider)


### PR DESCRIPTION
## Summary
- The Model tab's field grid (`ModelBuilderPanel.tsx`) was setting `DisplayName`/`DisplayCollectionName` as Dataverse-style `Label` objects (`{ UserLocalizedLabel: {...} }`), which the search box's placeholder builder interpolates directly as a string, producing "Search [object Object]...".
- Switches both back to plain strings ("Field" / "Fields"), matching what the search placeholder actually expects.

## Test plan
- [x] Storybook: Form/Xrm → Builder → Model tab — confirm the field grid's search box placeholder reads "Search Fields..." instead of "Search [object Object]..."